### PR TITLE
Fix #16 Changed name and set default to no for Sticky Hover Options

### DIFF
--- a/src/language/en-GB/en-GB.mod_osdonate.ini
+++ b/src/language/en-GB/en-GB.mod_osdonate.ini
@@ -68,8 +68,8 @@ MOD_OSDONATE_SUCCESS_RETURN_LABEL="Success return page"
 
 MOD_OSDONATE_TOP="top"
 
-MOD_OSDONATE_USE_STICKY_HOVER_DESC="This will allow you to set the module position to debug and the paypal button will always remain on the page, even when scrolling down.  If set to yes, then use debug position.  If set to no, then use a position other than debug."
-MOD_OSDONATE_USE_STICKY_HOVER_LABEL="Use sticky hover"
+MOD_OSDONATE_STICKY_HOVER_OPTIONS_DESC="This will allow you to set the module position to debug and the paypal button will always remain on the page, even when scrolling down.  If set to yes, then use debug position.  If set to no, then use a position other than debug."
+MOD_OSDONATE_STICKY_HOVER_OPTIONS_LABEL="Sticky Hover Options"
 
 MOD_OSDONATE_VERTICAL_DISTANCE_DESC="The distance from the vertical reference side in pixels.  However, no need to put px, just use the number, e.g. 5.  If you want it to be against the side, leave it as 0."
 MOD_OSDONATE_VERTICAL_DISTANCE_LABEL="Vertical distance"

--- a/src/mod_osdonate.xml
+++ b/src/mod_osdonate.xml
@@ -75,8 +75,8 @@
             </fieldset>
 
             <fieldset name="sticky_hover" label="MOD_OSDONATE_STICKY_HOVER_OPTIONS">
-                <field name="use_sticky_hover" type="radio" default="1" label="MOD_OSDONATE_USE_STICKY_HOVER_LABEL"
-                       description="MOD_OSDONATE_USE_STICKY_HOVER_DESC">
+                <field name="use_sticky_hover" type="radio" default="0" label="MOD_OSDONATE_STICKY_HOVER_OPTIONS_LABEL"
+                       description="MOD_OSDONATE_STICKY_HOVER_OPTIONS_DESC">
                     <option value="1">JYES</option>
                     <option value="0">JNO</option>
                 </field>


### PR DESCRIPTION
Set the default value to be off and changed the name to Sticky Hover Options.